### PR TITLE
Fix webkitBackdropFilter TypeScript type error

### DIFF
--- a/app/components/NavigationClient.tsx
+++ b/app/components/NavigationClient.tsx
@@ -81,7 +81,7 @@ export default function NavigationClient({ hideMobile = false, showBlog: propSho
     const isActive = liquidGlassAvailable && liquidGlass && supportsBackdropFilterUrl();
     if (!isActive) {
       el.style.backdropFilter = 'blur(24px)';
-      el.style.webkitBackdropFilter = 'blur(24px)';
+      (el.style as Record<string, unknown>)['webkitBackdropFilter'] = 'blur(24px)';
       return;
     }
     const rect = el.getBoundingClientRect();
@@ -98,7 +98,7 @@ export default function NavigationClient({ hideMobile = false, showBlog: propSho
     });
     const value = `blur(3px) url('${filterUrl}') blur(1px) brightness(1.1) saturate(1.3)`;
     el.style.backdropFilter = value;
-    el.style.webkitBackdropFilter = value;
+    (el.style as Record<string, unknown>)['webkitBackdropFilter'] = value;
   }, [liquidGlass, liquidGlassAvailable]);
 
   useEffect(() => {

--- a/app/components/ThemeProvider.tsx
+++ b/app/components/ThemeProvider.tsx
@@ -259,12 +259,12 @@ export function ThemeProvider({ children, liquidGlassAvailable = false }: ThemeP
       const value = getIconLiquidGlassFilter();
       icons.forEach((el) => {
         el.style.backdropFilter = value;
-        el.style.webkitBackdropFilter = value;
+        (el.style as Record<string, unknown>)['webkitBackdropFilter'] = value;
       });
     } else {
       icons.forEach((el) => {
         el.style.backdropFilter = '';
-        el.style.webkitBackdropFilter = '';
+        (el.style as Record<string, unknown>)['webkitBackdropFilter'] = '';
       });
     }
   }, [liquidGlass, liquidGlassAvailable]);


### PR DESCRIPTION
Use bracket notation with type assertion for the vendor-prefixed CSS property, which is not in the CSSStyleDeclaration type.

Made-with: Cursor