### PR TITLE
Add Feature Flags page for local Vercel flag overrides

### DIFF
--- a/app/components/NavigationClient.tsx
+++ b/app/components/NavigationClient.tsx
@@ -121,6 +121,12 @@ export default function NavigationClient({ hideMobile = false, showBlog: propSho
   });
   const [showBlog, setShowBlog] = useState(() => {
     if (typeof window !== 'undefined') {
+      // Check cookie override from Feature Flags page first
+      const cookieMatch = document.cookie.split('; ').find(c => c.startsWith('ff-blog-enabled='));
+      if (cookieMatch) {
+        return cookieMatch.split('=')[1] === 'true' || propShowBlog;
+      }
+      // Fall back to legacy localStorage override
       const localStorageValue = localStorage.getItem('college-blogs-enabled');
       if (localStorageValue !== null) {
         return localStorageValue === 'true' || propShowBlog;
@@ -133,8 +139,15 @@ export default function NavigationClient({ hideMobile = false, showBlog: propSho
   useEffect(() => {
     const checkBlogFlag = () => {
       if (typeof window !== 'undefined') {
+        // Check cookie override from Feature Flags page first
+        const cookieMatch = document.cookie.split('; ').find(c => c.startsWith('ff-blog-enabled='));
+        if (cookieMatch) {
+          setShowBlog(cookieMatch.split('=')[1] === 'true' || propShowBlog);
+          return;
+        }
+        // Fall back to legacy localStorage override
         const localStorageValue = localStorage.getItem('college-blogs-enabled');
-        const enabled = localStorageValue !== null 
+        const enabled = localStorageValue !== null
           ? localStorageValue === 'true'
           : defaultEnabled;
         setShowBlog(enabled || propShowBlog);
@@ -149,12 +162,12 @@ export default function NavigationClient({ hideMobile = false, showBlog: propSho
       }
     };
     window.addEventListener('storage', handleStorageChange);
-    
+
     const handleBlogEnabled = () => checkBlogFlag();
     const handleBlogDisabled = () => checkBlogFlag();
     window.addEventListener('college-blogs-enabled', handleBlogEnabled);
     window.addEventListener('college-blogs-disabled', handleBlogDisabled);
-    
+
     return () => {
       window.removeEventListener('storage', handleStorageChange);
       window.removeEventListener('college-blogs-enabled', handleBlogEnabled);

--- a/app/settings/feature-flags/page.tsx
+++ b/app/settings/feature-flags/page.tsx
@@ -131,9 +131,10 @@ function OverrideControl({
         </svg>
       </button>
 
-      <div
+      <label
+        htmlFor={`flag-toggle-${flagKey}`}
         className="toggle-switch"
-        style={{ opacity: state === 'cloud' ? 0.4 : 1, transition: 'opacity 0.15s ease-out' }}
+        style={{ opacity: state === 'cloud' ? 0.4 : 1, transition: 'opacity 0.15s ease-out', cursor: 'pointer' }}
       >
         <input
           type="checkbox"
@@ -142,7 +143,7 @@ function OverrideControl({
           onChange={handleToggleChange}
         />
         <span className="toggle-slider" />
-      </div>
+      </label>
     </div>
   );
 }

--- a/app/settings/feature-flags/page.tsx
+++ b/app/settings/feature-flags/page.tsx
@@ -1,0 +1,279 @@
+"use client";
+
+import Link from "next/link";
+import { useSearchParams } from "next/navigation";
+import { useState, useEffect, useCallback, Suspense } from "react";
+import Navigation from "../../components/Navigation";
+import { LoadingDots } from "../../components/LoadingAnim";
+
+const FLAG_COOKIE_PREFIX = 'ff-';
+const FLAG_COOKIE_MAX_AGE = 60 * 60 * 24 * 7; // 7 days
+
+const FLAGS = [
+  {
+    key: 'blog-enabled',
+    name: 'Blog page',
+    description: 'Show the blog in navigation and allow access to blog pages',
+  },
+  {
+    key: 'popular-stories-enabled',
+    name: 'Popular Stories',
+    description: 'Show the Popular Stories section on the home page',
+  },
+  {
+    key: 'year-slider-enabled',
+    name: 'Year slider',
+    description: 'Show the Year 1/Year 2 slider on the blog page',
+  },
+  {
+    key: 'in-post-search-bar-enabled',
+    name: 'In-post search bar',
+    description: 'Show the search bar on every blog post',
+  },
+  {
+    key: 'in-post-search-bar-fmp-enabled',
+    name: 'In-post search bar (FMP only)',
+    description: 'Show the search bar on the FMP post only',
+  },
+  {
+    key: 'corner-smoothing-enabled',
+    name: 'Corner smoothing toggle',
+    description: 'Show the corner smoothing toggle in Settings',
+  },
+  {
+    key: 'liquid-glass-enabled',
+    name: 'Liquid Glass toggle',
+    description: 'Show the Liquid Glass toggle in Settings',
+  },
+];
+
+type OverrideState = 'cloud' | 'on' | 'off';
+
+function getCookieOverride(key: string): OverrideState {
+  if (typeof document === 'undefined') return 'cloud';
+  const cookieName = FLAG_COOKIE_PREFIX + key;
+  const match = document.cookie.split('; ').find(c => c.startsWith(cookieName + '='));
+  if (!match) return 'cloud';
+  return match.split('=')[1] === 'true' ? 'on' : 'off';
+}
+
+function setCookieOverride(key: string, state: OverrideState) {
+  const cookieName = FLAG_COOKIE_PREFIX + key;
+  if (state === 'cloud') {
+    document.cookie = `${cookieName}=; path=/; max-age=0`;
+    if (key === 'blog-enabled') {
+      localStorage.removeItem('college-blogs-enabled');
+      window.dispatchEvent(new Event('college-blogs-disabled'));
+    }
+  } else {
+    const value = state === 'on' ? 'true' : 'false';
+    document.cookie = `${cookieName}=${value}; path=/; max-age=${FLAG_COOKIE_MAX_AGE}`;
+    if (key === 'blog-enabled') {
+      if (state === 'on') {
+        localStorage.setItem('college-blogs-enabled', 'true');
+        window.dispatchEvent(new Event('college-blogs-enabled'));
+      } else {
+        localStorage.removeItem('college-blogs-enabled');
+        window.dispatchEvent(new Event('college-blogs-disabled'));
+      }
+    }
+  }
+}
+
+function cycleState(current: OverrideState): OverrideState {
+  if (current === 'cloud') return 'on';
+  if (current === 'on') return 'off';
+  return 'cloud';
+}
+
+function OverrideControl({
+  state,
+  onSelect,
+}: {
+  state: OverrideState;
+  onSelect: (next: OverrideState) => void;
+}) {
+  const segments: { value: OverrideState; label: string }[] = [
+    { value: 'cloud', label: 'Cloud' },
+    { value: 'on', label: 'On' },
+    { value: 'off', label: 'Off' },
+  ];
+
+  return (
+    <div
+      style={{
+        display: 'flex',
+        gap: '2px',
+        padding: '3px',
+        background: 'rgba(120,120,128,0.12)',
+        borderRadius: '10px',
+        flexShrink: 0,
+      }}
+    >
+      {segments.map(seg => {
+        const isSelected = state === seg.value;
+        let bg = 'transparent';
+        let color = 'var(--secondary)';
+        if (isSelected) {
+          if (seg.value === 'cloud') {
+            bg = 'var(--container-background)';
+            color = 'var(--primary)';
+          } else if (seg.value === 'on') {
+            bg = 'var(--accent)';
+            color = '#fff';
+          } else {
+            bg = '#FF3B30';
+            color = '#fff';
+          }
+        }
+        return (
+          <button
+            key={seg.value}
+            onClick={(e) => {
+              e.stopPropagation();
+              e.preventDefault();
+              onSelect(seg.value);
+            }}
+            style={{
+              padding: '5px 11px',
+              borderRadius: '7px',
+              border: 'none',
+              cursor: 'pointer',
+              fontSize: '13px',
+              fontWeight: isSelected ? 600 : 400,
+              background: bg,
+              color,
+              transition: 'all 0.15s ease-out',
+              fontFamily: 'var(--body)',
+              boxShadow: isSelected ? '0 1px 3px rgba(0,0,0,0.15)' : 'none',
+            }}
+          >
+            {seg.label}
+          </button>
+        );
+      })}
+    </div>
+  );
+}
+
+function FeatureFlagsContent() {
+  const searchParams = useSearchParams();
+  const from = searchParams.get('from') || '/settings';
+  const [overrides, setOverrides] = useState<Record<string, OverrideState>>({});
+  const [mounted, setMounted] = useState(false);
+
+  useEffect(() => {
+    const initial: Record<string, OverrideState> = {};
+    for (const flag of FLAGS) {
+      initial[flag.key] = getCookieOverride(flag.key);
+    }
+    setOverrides(initial);
+    setMounted(true);
+  }, []);
+
+  const handleSelect = useCallback((key: string, next: OverrideState) => {
+    setCookieOverride(key, next);
+    setOverrides(prev => ({ ...prev, [key]: next }));
+  }, []);
+
+  const handleResetAll = useCallback(() => {
+    for (const flag of FLAGS) {
+      setCookieOverride(flag.key, 'cloud');
+    }
+    const reset: Record<string, OverrideState> = {};
+    for (const flag of FLAGS) {
+      reset[flag.key] = 'cloud';
+    }
+    setOverrides(reset);
+  }, []);
+
+  const hasAnyOverride = mounted && Object.values(overrides).some(v => v !== 'cloud');
+
+  return (
+    <>
+      <div className="top-app-bar">
+        <div className="top-app-bar-container back-only">
+          <Link href={from} className="top-app-bar-icon" aria-label="Back">
+            <svg width="10" height="20" viewBox="0 0 10 20" fill="none" xmlns="http://www.w3.org/2000/svg">
+              <path fillRule="evenodd" clipRule="evenodd" d="M9.56416 2.15216C9.85916 1.86116 9.86316 1.38616 9.57216 1.09116C9.28116 0.797162 8.80616 0.794162 8.51116 1.08516L0.733159 8.75516C0.397159 9.08616 0.212158 9.52916 0.212158 10.0012C0.212158 10.4722 0.397159 10.9162 0.733159 11.2472L8.51116 18.9162C8.65716 19.0592 8.84716 19.1312 9.03816 19.1312C9.23116 19.1312 9.42516 19.0562 9.57216 18.9082C9.86316 18.6132 9.85916 18.1382 9.56416 17.8472L1.78716 10.1782C1.72116 10.1152 1.71216 10.0402 1.71216 10.0012C1.71216 9.96216 1.72116 9.88616 1.78716 9.82316L9.56416 2.15216Z" fill="var(--primary)"/>
+            </svg>
+          </Link>
+          <div className="title-container">
+            <div className="title">Feature Flags</div>
+          </div>
+        </div>
+      </div>
+
+      <div className="main-content" style={{ animation: 'fadeInUp 0.4s cubic-bezier(0.2, 0.9, 0.3, 1) forwards', opacity: 0 }}>
+        <div className="container" style={{ padding: 'var(--padding-xll)' }}>
+          <div className="information-wrapper">
+            <div className="information">
+              Override Vercel feature flags locally. Changes take effect on the next page load. Overrides are stored as cookies and do not affect other users.
+            </div>
+          </div>
+        </div>
+
+        <div className="list-group">
+          {FLAGS.map(flag => {
+            const state = mounted ? (overrides[flag.key] ?? 'cloud') : 'cloud';
+            return (
+              <div key={flag.key} className="list3" style={{ cursor: 'default' }}>
+                <div className="test-toggle-group" style={{ flex: 1 }}>
+                  <div className="body-text">{flag.name}</div>
+                  <div className="information-wrapper">
+                    <div className="information">{flag.description}</div>
+                  </div>
+                </div>
+                {mounted && (
+                  <OverrideControl
+                    state={state}
+                    onSelect={(next) => handleSelect(flag.key, next)}
+                  />
+                )}
+              </div>
+            );
+          })}
+        </div>
+
+        {hasAnyOverride && (
+          <>
+            <div className="container1" />
+            <div className="list-group">
+              <button
+                className="list3"
+                onClick={handleResetAll}
+                style={{ cursor: 'pointer' }}
+              >
+                <div className="test-toggle-group">
+                  <div className="body-text" style={{ color: '#FF3B30' }}>Reset all overrides</div>
+                  <div className="information-wrapper">
+                    <div className="information">Restore all flags to their cloud values</div>
+                  </div>
+                </div>
+              </button>
+            </div>
+          </>
+        )}
+
+        <div className="container1" />
+      </div>
+    </>
+  );
+}
+
+export default function FeatureFlagsPage() {
+  return (
+    <div className="index settings-page">
+      <div className="containers">
+        <Navigation hideMobile={true} />
+        <Suspense fallback={
+          <div style={{ display: 'flex', justifyContent: 'center', alignItems: 'center', minHeight: '400px' }}>
+            <LoadingDots />
+          </div>
+        }>
+          <FeatureFlagsContent />
+        </Suspense>
+      </div>
+    </div>
+  );
+}

--- a/app/settings/feature-flags/page.tsx
+++ b/app/settings/feature-flags/page.tsx
@@ -80,78 +80,69 @@ function setCookieOverride(key: string, state: OverrideState) {
   }
 }
 
-function cycleState(current: OverrideState): OverrideState {
-  if (current === 'cloud') return 'on';
-  if (current === 'on') return 'off';
-  return 'cloud';
-}
-
 function OverrideControl({
+  flagKey,
   state,
   onSelect,
 }: {
+  flagKey: string;
   state: OverrideState;
   onSelect: (next: OverrideState) => void;
 }) {
-  const segments: { value: OverrideState; label: string }[] = [
-    { value: 'cloud', label: 'Cloud' },
-    { value: 'on', label: 'On' },
-    { value: 'off', label: 'Off' },
-  ];
+  const isOverriding = state !== 'cloud';
+  const isOn = state === 'on';
+
+  const handleToggleChange = () => {
+    if (state === 'cloud') {
+      onSelect('on');
+    } else {
+      onSelect(isOn ? 'off' : 'on');
+    }
+  };
 
   return (
-    <div
-      style={{
-        display: 'flex',
-        gap: '2px',
-        padding: '3px',
-        background: 'rgba(120,120,128,0.12)',
-        borderRadius: '10px',
-        flexShrink: 0,
-      }}
-    >
-      {segments.map(seg => {
-        const isSelected = state === seg.value;
-        let bg = 'transparent';
-        let color = 'var(--secondary)';
-        if (isSelected) {
-          if (seg.value === 'cloud') {
-            bg = 'var(--container-background)';
-            color = 'var(--primary)';
-          } else if (seg.value === 'on') {
-            bg = 'var(--accent)';
-            color = '#fff';
-          } else {
-            bg = '#FF3B30';
-            color = '#fff';
-          }
-        }
-        return (
-          <button
-            key={seg.value}
-            onClick={(e) => {
-              e.stopPropagation();
-              e.preventDefault();
-              onSelect(seg.value);
-            }}
-            style={{
-              padding: '5px 11px',
-              borderRadius: '7px',
-              border: 'none',
-              cursor: 'pointer',
-              fontSize: '13px',
-              fontWeight: isSelected ? 600 : 400,
-              background: bg,
-              color,
-              transition: 'all 0.15s ease-out',
-              fontFamily: 'var(--body)',
-              boxShadow: isSelected ? '0 1px 3px rgba(0,0,0,0.15)' : 'none',
-            }}
-          >
-            {seg.label}
-          </button>
-        );
-      })}
+    <div style={{ display: 'flex', alignItems: 'center', gap: '10px', flexShrink: 0 }}>
+      <button
+        onClick={(e) => {
+          e.stopPropagation();
+          e.preventDefault();
+          onSelect('cloud');
+        }}
+        aria-label="Revert to cloud value"
+        style={{
+          opacity: isOverriding ? 1 : 0,
+          pointerEvents: isOverriding ? 'auto' : 'none',
+          transition: 'opacity 0.15s ease-out',
+          width: '22px',
+          height: '22px',
+          borderRadius: '50%',
+          background: 'rgba(120,120,128,0.18)',
+          border: 'none',
+          cursor: 'pointer',
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          padding: 0,
+          flexShrink: 0,
+        }}
+      >
+        <svg width="8" height="8" viewBox="0 0 8 8" fill="none">
+          <path d="M1 1L7 7M7 1L1 7" stroke="var(--secondary)" strokeWidth="1.5" strokeLinecap="round"/>
+        </svg>
+      </button>
+
+      <div
+        className="toggle-switch"
+        style={{ opacity: state === 'cloud' ? 0.4 : 1, transition: 'opacity 0.15s ease-out' }}
+      >
+        <input
+          type="checkbox"
+          id={`flag-toggle-${flagKey}`}
+          checked={isOn}
+          onChange={handleToggleChange}
+        />
+        <span className="toggle-slider" />
+      </div>
     </div>
   );
 }
@@ -205,7 +196,7 @@ function FeatureFlagsContent() {
       </div>
 
       <div className="main-content" style={{ animation: 'fadeInUp 0.4s cubic-bezier(0.2, 0.9, 0.3, 1) forwards', opacity: 0 }}>
-        <div className="container" style={{ padding: 'var(--padding-xll)' }}>
+        <div style={{ padding: 'var(--padding-xll)' }}>
           <div className="information-wrapper">
             <div className="information">
               Override Vercel feature flags locally. Changes take effect on the next page load. Overrides are stored as cookies and do not affect other users.
@@ -226,6 +217,7 @@ function FeatureFlagsContent() {
                 </div>
                 {mounted && (
                   <OverrideControl
+                    flagKey={flag.key}
                     state={state}
                     onSelect={(next) => handleSelect(flag.key, next)}
                   />

--- a/app/settings/page.tsx
+++ b/app/settings/page.tsx
@@ -76,7 +76,6 @@ function SettingsContent() {
   const { theme, setTheme, accentColor, setAccentColor, blurEnabled, setBlurEnabled, cornerSmoothing, setCornerSmoothing, cornerSmoothingSupported, cornerSmoothingAvailable, liquidGlass, setLiquidGlass, liquidGlassAvailable } = useTheme();
   const [mounted, setMounted] = useState(false);
   const [devOptionsEnabled, setDevOptionsEnabled] = useState(false);
-  const [blogOverride, setBlogOverride] = useState(false);
   const searchParams = useSearchParams();
   const from = searchParams.get('from') || '/';
 
@@ -89,7 +88,6 @@ function SettingsContent() {
   useEffect(() => {
     const checkDevOptions = () => {
       setDevOptionsEnabled(localStorage.getItem('developer-options-enabled') === 'true');
-      setBlogOverride(localStorage.getItem('college-blogs-enabled') === 'true');
     };
     checkDevOptions();
     window.addEventListener('developer-options-changed', checkDevOptions);
@@ -362,33 +360,18 @@ function SettingsContent() {
               <div className="title">Developer options</div>
             </div>
             <div className="list-group">
-              <label htmlFor="blog-override-toggle" className="list3" style={{ cursor: 'pointer' }}>
+              <a href="/settings/feature-flags" className="list3" role="button" aria-label="Feature Flags">
                 <div className="test-toggle-group">
-                  <div className="body-text">Blog page</div>
+                  <div className="body-text">Feature Flags</div>
                   <div className="information-wrapper">
-                    <div className="information">Override the cloud flag and show the Blog tab</div>
+                    <div className="information">Locally override Vercel feature flags</div>
                   </div>
                 </div>
-                <div className="toggle-switch">
-                  <input
-                    type="checkbox"
-                    checked={blogOverride}
-                    onChange={(e) => {
-                      const enabled = e.target.checked;
-                      setBlogOverride(enabled);
-                      if (enabled) {
-                        localStorage.setItem('college-blogs-enabled', 'true');
-                        window.dispatchEvent(new Event('college-blogs-enabled'));
-                      } else {
-                        localStorage.removeItem('college-blogs-enabled');
-                        window.dispatchEvent(new Event('college-blogs-disabled'));
-                      }
-                    }}
-                    id="blog-override-toggle"
-                  />
-                  <span className="toggle-slider"></span>
-                </div>
-              </label>
+                <div className="list-item-separator" />
+                <svg width="8" height="14" viewBox="0 0 8 14" fill="none">
+                  <path d="M1 1L7 7L1 13" stroke="var(--secondary)" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" />
+                </svg>
+              </a>
               <a href="/playground" className="list3" role="button" aria-label="Component Playground">
                 <div className="test-toggle-group">
                   <div className="body-text">Component Playground</div>

--- a/lib/getBlogFlag.ts
+++ b/lib/getBlogFlag.ts
@@ -1,9 +1,18 @@
 /**
  * Gets the blog-enabled flag value.
+ * Checks for a local developer override cookie (ff-blog-enabled) first.
  * Uses Vercel Flags when FLAGS env var is set, otherwise falls back to true.
  * This allows the app to build and run before Vercel Flags is configured.
  */
 export async function getBlogEnabled(): Promise<boolean> {
+  try {
+    const { cookies } = await import('next/headers');
+    const cookieStore = await cookies();
+    const override = cookieStore.get('ff-blog-enabled');
+    if (override) return override.value === 'true';
+  } catch {
+    // cookies() not available during static generation
+  }
   if (!process.env.FLAGS) {
     return true;
   }

--- a/lib/getCornerSmoothingFlag.ts
+++ b/lib/getCornerSmoothingFlag.ts
@@ -1,9 +1,18 @@
 /**
  * Gets the corner-smoothing-enabled flag value.
+ * Checks for a local developer override cookie (ff-corner-smoothing-enabled) first.
  * Uses Vercel Flags when FLAGS env var is set, otherwise falls back to false.
  * Set CORNER_SMOOTHING_ENABLED=true in .env.local to test locally without Vercel Flags.
  */
 export async function getCornerSmoothingEnabled(): Promise<boolean> {
+  try {
+    const { cookies } = await import('next/headers');
+    const cookieStore = await cookies();
+    const override = cookieStore.get('ff-corner-smoothing-enabled');
+    if (override) return override.value === 'true';
+  } catch {
+    // cookies() not available during static generation
+  }
   if (process.env.CORNER_SMOOTHING_ENABLED === 'true') {
     return true;
   }

--- a/lib/getInPostSearchBarFlag.ts
+++ b/lib/getInPostSearchBarFlag.ts
@@ -1,8 +1,17 @@
 /**
  * Gets the in-post-search-bar-enabled flag value.
+ * Checks for a local developer override cookie (ff-in-post-search-bar-enabled) first.
  * Uses Vercel Flags when FLAGS env var is set, otherwise falls back to false.
  */
 export async function getInPostSearchBarEnabled(): Promise<boolean> {
+  try {
+    const { cookies } = await import('next/headers');
+    const cookieStore = await cookies();
+    const override = cookieStore.get('ff-in-post-search-bar-enabled');
+    if (override) return override.value === 'true';
+  } catch {
+    // cookies() not available during static generation
+  }
   if (!process.env.FLAGS) {
     return false;
   }

--- a/lib/getInPostSearchBarFmpFlag.ts
+++ b/lib/getInPostSearchBarFmpFlag.ts
@@ -1,8 +1,17 @@
 /**
  * Gets the in-post-search-bar-fmp-enabled flag value.
+ * Checks for a local developer override cookie (ff-in-post-search-bar-fmp-enabled) first.
  * Uses Vercel Flags when FLAGS env var is set, otherwise falls back to true.
  */
 export async function getInPostSearchBarFmpEnabled(): Promise<boolean> {
+  try {
+    const { cookies } = await import('next/headers');
+    const cookieStore = await cookies();
+    const override = cookieStore.get('ff-in-post-search-bar-fmp-enabled');
+    if (override) return override.value === 'true';
+  } catch {
+    // cookies() not available during static generation
+  }
   if (!process.env.FLAGS) {
     return true;
   }

--- a/lib/getLiquidGlassFlag.ts
+++ b/lib/getLiquidGlassFlag.ts
@@ -1,9 +1,18 @@
 /**
  * Gets the liquid-glass-enabled flag value.
+ * Checks for a local developer override cookie (ff-liquid-glass-enabled) first.
  * Uses Vercel Flags when FLAGS env var is set, otherwise falls back to false.
  * Set LIQUID_GLASS_ENABLED=true in .env.local to test locally without Vercel Flags.
  */
 export async function getLiquidGlassEnabled(): Promise<boolean> {
+  try {
+    const { cookies } = await import('next/headers');
+    const cookieStore = await cookies();
+    const override = cookieStore.get('ff-liquid-glass-enabled');
+    if (override) return override.value === 'true';
+  } catch {
+    // cookies() not available during static generation
+  }
   if (process.env.LIQUID_GLASS_ENABLED === 'true') {
     return true;
   }

--- a/lib/getPopularStoriesFlag.ts
+++ b/lib/getPopularStoriesFlag.ts
@@ -1,8 +1,17 @@
 /**
  * Gets the popular-stories-enabled flag value.
+ * Checks for a local developer override cookie (ff-popular-stories-enabled) first.
  * Uses Vercel Flags when FLAGS env var is set, otherwise falls back to true.
  */
 export async function getPopularStoriesEnabled(): Promise<boolean> {
+  try {
+    const { cookies } = await import('next/headers');
+    const cookieStore = await cookies();
+    const override = cookieStore.get('ff-popular-stories-enabled');
+    if (override) return override.value === 'true';
+  } catch {
+    // cookies() not available during static generation
+  }
   if (!process.env.FLAGS) {
     return true;
   }

--- a/lib/getYearSliderFlag.ts
+++ b/lib/getYearSliderFlag.ts
@@ -1,9 +1,18 @@
 /**
  * Gets the year-slider-enabled flag value.
+ * Checks for a local developer override cookie (ff-year-slider-enabled) first.
  * Uses Vercel Flags when FLAGS env var is set, otherwise falls back to true.
  * This allows the app to build and run before Vercel Flags is configured.
  */
 export async function getYearSliderEnabled(): Promise<boolean> {
+  try {
+    const { cookies } = await import('next/headers');
+    const cookieStore = await cookies();
+    const override = cookieStore.get('ff-year-slider-enabled');
+    if (override) return override.value === 'true';
+  } catch {
+    // cookies() not available during static generation
+  }
   if (!process.env.FLAGS) {
     return true;
   }


### PR DESCRIPTION
Adds /settings/feature-flags (developer options only) with a segmented
Cloud/On/Off control per flag. Overrides are stored as cookies (ff-<flag-key>)
so they work for both server-rendered and client-rendered content.

- Replace the Blog page toggle in Developer Options with a Feature Flags link
- Create app/settings/feature-flags/page.tsx with all 7 flags listed
- Update all lib flag helpers to check for cookie overrides before Vercel
- Update NavigationClient to honour ff-blog-enabled cookie alongside the
  existing college-blogs-enabled localStorage key for backward compatibility

https://claude.ai/code/session_01Vtm5C9vSzS8nyuP96c3r5T