### PR TITLE
claude/fix-mobile-nav-padding-kYmGM

### DIFF
--- a/app/index.css
+++ b/app/index.css
@@ -1869,9 +1869,8 @@ html[data-theme="dark"][data-liquid-glass="true"] .top-app-bar-icon:hover {
     transform: translateX(-50%);
     width: calc(100% - 32px);
     max-width: 480px;
-    bottom: 16px;
+    bottom: calc(16px + env(safe-area-inset-bottom, 0px));
     padding: 8px;
-    padding-bottom: calc(8px + env(safe-area-inset-bottom, 0px));
     box-sizing: border-box;
     background: color-mix(in srgb, var(--container-background) 85%, transparent);
     border-radius: var(--br-xl);


### PR DESCRIPTION
The nav bar had `bottom: 16px` combined with `padding-bottom: calc(8px + env(safe-area-inset-bottom, 0px))`. On devices with a home indicator (safe-area-inset-bottom ~34px), this created a 42px bottom vs 8px top asymmetry inside the nav bar, making it appear to have extra padding. It also caused the padding to "fix itself" when env(safe-area-inset-bottom) changed (e.g. Android gesture nav bar hiding after interaction).

Fix: Move env(safe-area-inset-bottom) to the `bottom` positioning so the nav bar floats entirely above the safe area zone with uniform 8px internal padding on all sides.

https://claude.ai/code/session_011fGraJBEnCL9MWd1WEquSx