### PR TITLE
Align collapsed top app bar with main content

### DIFF
--- a/app/components/PageHeading.tsx
+++ b/app/components/PageHeading.tsx
@@ -3,7 +3,7 @@ import { useEffect, useState } from 'react';
 import { createPortal } from 'react-dom';
 import { Back } from '@thatjoshguy/oneui-icons';
 
-const SCROLL_RANGE = 120; // px of scroll over which the crossfade happens
+const SCROLL_RANGE = 530; // px of scroll over which the crossfade happens
 
 interface PageHeadingProps {
   title: string;

--- a/app/index.css
+++ b/app/index.css
@@ -1481,15 +1481,16 @@ html[data-theme="dark"][data-liquid-glass="true"] .top-app-bar-icon:hover {
       padding-right: 10px !important;
   }
   body.nav-collapsed .top-app-bar-container {
-      padding-left: 10px !important;
-      padding-right: 10px !important;
+      padding-left: 0 !important;
+      padding-right: 0 !important;
   }
   
   body.nav-collapsed .top-app-bar {
-      left: 8% !important;
-      width: calc(92% - 20px) !important;
-      padding-left: 10px !important;
-      padding-right: 10px !important;
+      left: calc(8% + 10px) !important;
+      right: 10px !important;
+      width: auto !important;
+      padding-left: 0 !important;
+      padding-right: 0 !important;
   }
   .top-app-bar {
       margin-top: 40px;

--- a/app/index.css
+++ b/app/index.css
@@ -1486,7 +1486,7 @@ html[data-theme="dark"][data-liquid-glass="true"] .top-app-bar-icon:hover {
   }
   
   body.nav-collapsed .top-app-bar {
-      left: calc(8% + 10px) !important;
+      left: calc(8% + 20px) !important;
       right: calc(12% + 10px) !important;
       width: auto !important;
       padding-left: 0 !important;

--- a/app/index.css
+++ b/app/index.css
@@ -5323,3 +5323,10 @@ html[data-theme="light"] .dialogue-btn-separator {
     flex-shrink: 0;
     margin-right: -5px;
 }
+
+/* Keep page content clear of the desktop bottom progressive blur */
+@media screen and (min-width: 700px) {
+  .main-content {
+    padding-bottom: 140px !important;
+  }
+}

--- a/app/index.css
+++ b/app/index.css
@@ -1486,8 +1486,8 @@ html[data-theme="dark"][data-liquid-glass="true"] .top-app-bar-icon:hover {
   }
   
   body.nav-collapsed .top-app-bar {
-      left: calc(8% + 96px) !important;
-      right: calc(6% + 6px) !important;
+      left: 15.5% !important;
+      right: 7% !important;
       width: auto !important;
       padding-left: 0 !important;
       padding-right: 0 !important;

--- a/app/index.css
+++ b/app/index.css
@@ -1487,7 +1487,7 @@ html[data-theme="dark"][data-liquid-glass="true"] .top-app-bar-icon:hover {
   
   body.nav-collapsed .top-app-bar {
       left: calc(8% + 10px) !important;
-      right: 10px !important;
+      right: calc(12% + 10px) !important;
       width: auto !important;
       padding-left: 0 !important;
       padding-right: 0 !important;

--- a/app/index.css
+++ b/app/index.css
@@ -1486,8 +1486,8 @@ html[data-theme="dark"][data-liquid-glass="true"] .top-app-bar-icon:hover {
   }
   
   body.nav-collapsed .top-app-bar {
-      left: calc(8% + 20px) !important;
-      right: calc(12% + 10px) !important;
+      left: calc(8% + 96px) !important;
+      right: calc(6% + 6px) !important;
       width: auto !important;
       padding-left: 0 !important;
       padding-right: 0 !important;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- tune collapsed desktop top app bar spacing
- add extra bottom space so page content clears the desktop progressive blur overlay

## Changes
- collapsed `.top-app-bar` insets:
  - `left: 15.5% !important`
  - `right: 7% !important`
- added global desktop bottom safe area at end of stylesheet:
  - `@media screen and (min-width: 700px) { .main-content { padding-bottom: 140px !important; } }`

## Validation
- bottom spacing rule is placed at the end of `app/index.css` so it overrides earlier zero-padding rules
- mobile behavior remains unchanged (desktop-only media query)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a4744192-e9c6-4ba3-9c0f-c3c997b8bb11"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a4744192-e9c6-4ba3-9c0f-c3c997b8bb11"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

