### PR TITLE
feat: add custom button syntax for WP blog posts

### DIFF
--- a/app/blog/BlogButton.tsx
+++ b/app/blog/BlogButton.tsx
@@ -1,0 +1,20 @@
+import * as Icons from '@thatjoshguy/oneui-icons';
+
+interface BlogButtonProps {
+  label: string;
+  href: string;
+  iconName?: string;
+}
+
+export default function BlogButton({ label, href, iconName }: BlogButtonProps) {
+  const IconComponent = iconName ? (Icons as Record<string, React.ComponentType<{ size?: number; color?: string }>>)[iconName] : null;
+
+  return (
+    <div className="blog-button-wrapper">
+      <a href={href} className="blog-button" target="_blank" rel="noopener noreferrer">
+        {IconComponent && <IconComponent size={20} color="#fff" />}
+        <span>{label}</span>
+      </a>
+    </div>
+  );
+}

--- a/app/blog/BlogContent.tsx
+++ b/app/blog/BlogContent.tsx
@@ -6,8 +6,10 @@ import { enhanceAudioPlayer } from './enhanceAudioPlayer';
 import { enhanceWpBlockEmbeds } from './enhanceWpBlockEmbeds';
 import WordCounter from './WordCounter';
 import NativeSlideshow, { type SlideData } from './NativeSlideshow';
+import BlogButton from './BlogButton';
 
 const WORD_COUNTER_REGEX = /\{\{WORD_COUNTER\}\}:(\d+)/;
+const BUTTON_REGEX = /\{\{BUTTON:([^|]+)\|([^|}]+)(?:\|([^}]+))?\}\}/;
 
 const SLIDESHOW_GALLERY_RE =
   /<figure\b[^>]*class="[^"]*(?:is-style-slideshow|is-slideshow)[^"]*"[^>]*>[\s\S]*?<\/figure>(?:\s*<\/figure>)*/gi;
@@ -144,12 +146,26 @@ export default function BlogContent({ content }: BlogContentProps) {
         );
       }
 
+      const btnMatch = html.match(BUTTON_REGEX);
+      if (btnMatch) {
+        const [label, href, iconName] = [btnMatch[1], btnMatch[2], btnMatch[3]];
+        const [before, after] = html.split(btnMatch[0]);
+        return (
+          <div key={`html-${i}`}>
+            {before && <div dangerouslySetInnerHTML={{ __html: before }} />}
+            <BlogButton label={label} href={href} iconName={iconName} />
+            {after && <div dangerouslySetInnerHTML={{ __html: after }} />}
+          </div>
+        );
+      }
+
       return <div key={`html-${i}`} dangerouslySetInnerHTML={{ __html: html }} />;
     });
 
   const hasSlideshows = segments.some(s => s.type === 'slideshow');
+  const hasButtons = BUTTON_REGEX.test(content || '');
 
-  if (hasSlideshows || wordCountMatch) {
+  if (hasSlideshows || wordCountMatch || hasButtons) {
     return (
       <div ref={contentRef} className="body-text" style={bodyTextStyle}>
         {renderSegments(segments)}

--- a/app/blog/[slug]/[section]/page.tsx
+++ b/app/blog/[slug]/[section]/page.tsx
@@ -90,7 +90,7 @@ function processContentWithEmbeds(content: string): string {
   // Replace button syntax: (Label)[url]{IconName} or (Label)[url]
   // WordPress wraps standalone lines in <p> tags, so match through them
   processedContent = processedContent.replace(
-    /<p>\s*\(([^)]+)\)\[([^\]]+)\](?:\{([^}]+)\})?\s*<\/p>/g,
+    /<p[^>]*>\s*\(([^)]+)\)\[([^\]]+)\](?:\{([^}]+)\})?\s*<\/p>/g,
     (_match, label: string, href: string, icon?: string) => {
       return icon
         ? `{{BUTTON:${label}|${href}|${icon}}}`

--- a/app/blog/[slug]/[section]/page.tsx
+++ b/app/blog/[slug]/[section]/page.tsx
@@ -87,6 +87,17 @@ function processContentWithEmbeds(content: string): string {
 
   processedContent = replaceTransitModelPlaceholder(processedContent);
 
+  // Replace button syntax: (Label)[url]{IconName} or (Label)[url]
+  // WordPress wraps standalone lines in <p> tags, so match through them
+  processedContent = processedContent.replace(
+    /<p>\s*\(([^)]+)\)\[([^\]]+)\](?:\{([^}]+)\})?\s*<\/p>/g,
+    (_match, label: string, href: string, icon?: string) => {
+      return icon
+        ? `{{BUTTON:${label}|${href}|${icon}}}`
+        : `{{BUTTON:${label}|${href}}}`;
+    }
+  );
+
   return processedContent;
 }
 

--- a/app/blog/[slug]/page.tsx
+++ b/app/blog/[slug]/page.tsx
@@ -160,7 +160,7 @@ function processContentWithEmbeds(content: string): string {
   // Replace button syntax: (Label)[url]{IconName} or (Label)[url]
   // WordPress wraps standalone lines in <p> tags, so match through them
   processedContent = processedContent.replace(
-    /<p>\s*\(([^)]+)\)\[([^\]]+)\](?:\{([^}]+)\})?\s*<\/p>/g,
+    /<p[^>]*>\s*\(([^)]+)\)\[([^\]]+)\](?:\{([^}]+)\})?\s*<\/p>/g,
     (_match, label: string, href: string, icon?: string) => {
       return icon
         ? `{{BUTTON:${label}|${href}|${icon}}}`

--- a/app/blog/[slug]/page.tsx
+++ b/app/blog/[slug]/page.tsx
@@ -157,6 +157,17 @@ function processContentWithEmbeds(content: string): string {
 
   processedContent = replaceTransitModelPlaceholder(processedContent);
 
+  // Replace button syntax: (Label)[url]{IconName} or (Label)[url]
+  // WordPress wraps standalone lines in <p> tags, so match through them
+  processedContent = processedContent.replace(
+    /<p>\s*\(([^)]+)\)\[([^\]]+)\](?:\{([^}]+)\})?\s*<\/p>/g,
+    (_match, label: string, href: string, icon?: string) => {
+      return icon
+        ? `{{BUTTON:${label}|${href}|${icon}}}`
+        : `{{BUTTON:${label}|${href}}}`;
+    }
+  );
+
   return processedContent;
 }
 

--- a/app/blog/blog.css
+++ b/app/blog/blog.css
@@ -1648,6 +1648,7 @@ html[data-theme="dark"] .post-search-bar {
   margin: 24px 0;
 }
 
+.body-text .blog-button,
 .blog-button {
   display: flex;
   align-items: center;
@@ -1655,7 +1656,7 @@ html[data-theme="dark"] .post-search-bar {
   padding: 14px 28px;
   border-radius: var(--br-9xl);
   background-color: var(--accent);
-  color: #fff;
+  color: #fff !important;
   text-decoration: none;
   font-family: 'One UI Sans';
   font-weight: 600;

--- a/app/blog/blog.css
+++ b/app/blog/blog.css
@@ -1640,3 +1640,43 @@ html[data-theme="dark"] .post-search-bar {
     transform: translateY(0);
   }
 }
+
+/* Blog inline button (custom WP shortcode) */
+.blog-button-wrapper {
+  display: flex;
+  justify-content: center;
+  margin: 24px 0;
+}
+
+.blog-button {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 14px 28px;
+  border-radius: var(--br-9xl);
+  background-color: var(--accent);
+  color: #fff;
+  text-decoration: none;
+  font-family: 'One UI Sans';
+  font-weight: 600;
+  font-size: 16px;
+  transition: transform 0.2s ease-out, box-shadow 0.2s ease-out;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+  cursor: pointer;
+}
+
+.blog-button:hover {
+  transform: scale(1.03);
+  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.2);
+}
+
+.blog-button:active {
+  transform: scale(0.98);
+}
+
+@media screen and (max-width: 699px) {
+  .blog-button {
+    padding: 12px 22px;
+    font-size: 14px;
+  }
+}

--- a/app/index.css
+++ b/app/index.css
@@ -49,8 +49,8 @@ a:not(:any-link) {
 }
 
 /* Inline hyperlinks in prose / WordPress only — not list rows (list3/list4) */
-.body-text a:any-link:not(.list3):not(.list4),
-.body-text a:not(:any-link):not(.list3):not(.list4) {
+.body-text a:any-link:not(.list3):not(.list4):not(.blog-button),
+.body-text a:not(:any-link):not(.list3):not(.list4):not(.blog-button) {
   color: var(--accent);
 }
 

--- a/app/index.css
+++ b/app/index.css
@@ -1522,8 +1522,8 @@ html[data-theme="dark"][data-liquid-glass="true"] .top-app-bar-icon:hover {
       gap: 12px;
   }
   .main-content {
-      margin-left: 34%;
-      width: calc(100% - 34%);
+      margin-left: min(34%, 396px);
+      width: calc(100% - min(34%, 396px));
       max-width: 100%;
       padding-top: 16px;
       padding-left: 20px;
@@ -1532,7 +1532,7 @@ html[data-theme="dark"][data-liquid-glass="true"] .top-app-bar-icon:hover {
       box-sizing: border-box;
   }
   .top-app-bar-container {
-      padding-left: 36% !important;
+      padding-left: min(36%, 416px) !important;
       padding-right: 20px !important;
   }
   .containers {

--- a/app/index.css
+++ b/app/index.css
@@ -1523,12 +1523,13 @@ html[data-theme="dark"][data-liquid-glass="true"] .top-app-bar-icon:hover {
   }
   .main-content {
       margin-left: 34%;
-      width: 64%;
+      width: calc(100% - 34%);
       max-width: 100%;
       padding-top: 16px;
       padding-left: 20px;
       padding-right: 20px;
       align-items: flex-start;
+      box-sizing: border-box;
   }
   .top-app-bar-container {
       padding-left: 36% !important;
@@ -1545,7 +1546,7 @@ html[data-theme="dark"][data-liquid-glass="true"] .top-app-bar-icon:hover {
   }
   body.nav-collapsed .main-content {
       margin-left: 8% !important;
-      width: 80% !important;
+      width: calc(100% - 8%) !important;
       padding-left: 10px !important;
       padding-right: 10px !important;
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@flags-sdk/hypertune": "^0.2.0",
         "@flags-sdk/vercel": "^1.0.1",
-        "@thatjoshguy/oneui-icons": "^1.0.0",
+        "@thatjoshguy/oneui-icons": "^1.1.0",
         "@vercel/analytics": "^1.5.0",
         "@vercel/edge-config": "^1.4.3",
         "@vercel/flags-core": "^1.0.1",
@@ -2942,9 +2942,9 @@
       }
     },
     "node_modules/@thatjoshguy/oneui-icons": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@thatjoshguy/oneui-icons/-/oneui-icons-1.0.0.tgz",
-      "integrity": "sha512-/90Ta8hKl/RktmS3IHHAE+6TKKbffO391BLQTh+9TXcLdZNIeuEf6CiJd311rmwZlggREbSKZZlnGJvoIxn2KQ==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@thatjoshguy/oneui-icons/-/oneui-icons-1.1.0.tgz",
+      "integrity": "sha512-T0X54705IgwU15CYYNOFXZ7XDaQUuerK7QN9+cKzzWe9Vac5tTpsP9sRvSqKKp8B/Ti7nfY4L5W4w8K4aIBcLQ==",
       "license": "MIT",
       "peerDependencies": {
         "react": "^18.0.0"

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "dependencies": {
     "@flags-sdk/hypertune": "^0.2.0",
     "@flags-sdk/vercel": "^1.0.1",
-    "@thatjoshguy/oneui-icons": "^1.0.0",
+    "@thatjoshguy/oneui-icons": "^1.1.0",
     "@vercel/analytics": "^1.5.0",
     "@vercel/edge-config": "^1.4.3",
     "@vercel/flags-core": "^1.0.1",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds support for a custom button syntax in WordPress blog posts that renders as styled, accent-colored buttons with optional icons from `@thatjoshguy/oneui-icons`. Also fixes a layout issue with `main-content` not extending fully on wide viewports.

## Custom Button Syntax

```
(Button Label)[https://example.com]{IconName}
```

- `(...)` = button label text (required)
- `[...]` = button URL (required)
- `{...}` = PascalCase icon name from `@thatjoshguy/oneui-icons` (optional)

### Examples

- `(Download the kit)[https://example.com/kit]{Download}` -- button with icon
- `(Visit the site)[https://example.com]` -- button without icon
- `(Send me an email)[mailto:email@thatjoshguy.me]{Mail}` -- mailto with icon

Place the syntax on its own line in the WordPress editor. It renders as a centered block-level button below the surrounding content.

## Changes

### Button feature
- **`app/blog/BlogButton.tsx`** -- New component rendering the button with dynamic icon loading from `@thatjoshguy/oneui-icons`
- **`app/blog/[slug]/page.tsx`** -- Added button regex to `processContentWithEmbeds()` that converts syntax into `{{BUTTON:...}}` placeholders, matching `<p>` tags with any attributes (e.g. `class="wp-block-paragraph"`)
- **`app/blog/[slug]/[section]/page.tsx`** -- Same regex added to the section page's copy of `processContentWithEmbeds()`
- **`app/blog/BlogContent.tsx`** -- Extended segment rendering to detect `{{BUTTON:...}}` placeholders and render `<BlogButton>` React components
- **`app/blog/blog.css`** -- Added `.blog-button-wrapper` and `.blog-button` styles: white text/icons on `var(--accent)` background, pill shape, hover/active states matching the footer button design
- **`app/index.css`** -- Excluded `.blog-button` from the `.body-text a` color override so white text stays white on accent background

### Layout fix
- **`app/index.css`** -- Changed `.main-content` width from fixed `64%` to `calc(100% - 34%)` so it fills remaining space after the nav margin on wide viewports. Same fix for nav-collapsed state (`80%` -> `calc(100% - 8%)`).

### Dependency update
- Updated `@thatjoshguy/oneui-icons` from ^1.0.0 to ^1.1.0
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c5b76a87-158d-41eb-9d62-370275a082e9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c5b76a87-158d-41eb-9d62-370275a082e9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

