### PR TITLE
Add FMP blog view toggle (separated/combined) in Settings

### DIFF
--- a/app/blog/[slug]/FmpViewWrapper.tsx
+++ b/app/blog/[slug]/FmpViewWrapper.tsx
@@ -1,0 +1,108 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+import Link from 'next/link';
+import BlogContent from '../BlogContent';
+import { extractH1Sections } from '../../../lib/fmpSections';
+
+interface FmpViewWrapperProps {
+  rawContent: string;
+  processedContent: string;
+  slug: string;
+}
+
+export default function FmpViewWrapper({ rawContent, processedContent, slug }: FmpViewWrapperProps) {
+  const [combinedView, setCombinedView] = useState(false);
+  const [mounted, setMounted] = useState(false);
+
+  useEffect(() => {
+    setCombinedView(localStorage.getItem('fmpCombinedView') === 'true');
+    setMounted(true);
+  }, []);
+
+  const sections = extractH1Sections(rawContent);
+
+  if (sections.length === 0) {
+    return (
+      <div className="container settings" style={{ padding: '0', marginBottom: '0', maxWidth: '100%' }}>
+        <BlogContent content={processedContent} />
+      </div>
+    );
+  }
+
+  if (!mounted) {
+    return <SeparatedView sections={sections} slug={slug} />;
+  }
+
+  if (combinedView) {
+    return (
+      <>
+        <div className="container settings" style={{ padding: '0', marginBottom: '0', maxWidth: '100%' }}>
+          <BlogContent content={processedContent} />
+        </div>
+        <Disclaimer />
+      </>
+    );
+  }
+
+  return <SeparatedView sections={sections} slug={slug} />;
+}
+
+function SeparatedView({ sections, slug }: { sections: { title: string; slug: string }[]; slug: string }) {
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', width: '100%', maxWidth: '100%', boxSizing: 'border-box' }}>
+      <div className="list-group">
+        {sections.map((section) => (
+          <Link
+            key={section.slug}
+            href={`/blog/${slug}/${section.slug}`}
+            className="list3"
+            style={{
+              justifyContent: 'space-between',
+              textDecoration: 'none',
+              fontWeight: 600,
+              fontFamily: "'One UI Sans', sans-serif",
+              width: '100%',
+              maxWidth: '100%',
+              boxSizing: 'border-box',
+            }}
+          >
+            <span style={{ fontFamily: "'One UI Sans', sans-serif" }}>{section.title}</span>
+            <svg width="10" height="18" viewBox="0 0 10 18" fill="none" xmlns="http://www.w3.org/2000/svg" style={{ flexShrink: 0, opacity: 0.45 }}>
+              <path fillRule="evenodd" clipRule="evenodd" d="M0.43584 1.15216C0.14084 0.861162 0.13684 0.386162 0.42784 0.091162C0.71884 -0.202838 1.19384 -0.205838 1.48884 0.085162L9.26684 7.75516C9.60284 8.08616 9.78784 8.52916 9.78784 9.00116C9.78784 9.47216 9.60284 9.91616 9.26684 10.2472L1.48884 17.9162C1.34284 18.0592 1.15284 18.1312 0.96184 18.1312C0.76884 18.1312 0.57484 18.0562 0.42784 17.9082C0.13684 17.6132 0.14084 17.1382 0.43584 16.8472L8.21284 9.17816C8.27884 9.11516 8.28784 9.04016 8.28784 9.00116C8.28784 8.96216 8.27884 8.88616 8.21284 8.82316L0.43584 1.15216Z" fill="currentColor"/>
+            </svg>
+          </Link>
+        ))}
+      </div>
+      <Disclaimer />
+    </div>
+  );
+}
+
+function Disclaimer() {
+  return (
+    <div style={{
+      marginTop: 24,
+      padding: '20px 20px',
+      borderRadius: 'var(--br-9xl)',
+      background: 'var(--container-background)',
+      fontFamily: "'One UI Sans', sans-serif",
+      fontSize: '0.875rem',
+      lineHeight: 1.6,
+      color: 'var(--secondary)',
+      width: '100%',
+      maxWidth: '100%',
+      boxSizing: 'border-box',
+    }}>
+      <p style={{ margin: '0 0 8px 0' }}>
+        I confirm that the following website and associated work within is all my own work and does not include any work completed by anyone else other than myself.
+      </p>
+      <p style={{ margin: 0, fontWeight: 600, color: 'var(--primary)' }}>
+        Josh Skinner<br />
+        <a href="mailto:10694305@student.bpc.ac.uk" style={{ color: 'var(--accent)', textDecoration: 'none' }}>
+          10694305@student.bpc.ac.uk
+        </a>
+      </p>
+    </div>
+  );
+}

--- a/app/blog/[slug]/page.tsx
+++ b/app/blog/[slug]/page.tsx
@@ -11,7 +11,8 @@ import Link from "next/link";
 import TableOfContents from "../TableOfContents";
 import BlogContent from "../BlogContent";
 import PostSearchBar from "../PostSearchBar";
-import { FMP_SLUG, extractH1Sections } from "../../../lib/fmpSections";
+import { FMP_SLUG } from "../../../lib/fmpSections";
+import FmpViewWrapper from "./FmpViewWrapper";
 import { replaceTransitModelPlaceholder } from "../../../lib/transitModelSketchfabEmbed";
 import { getInPostSearchBarEnabled } from "../../../lib/getInPostSearchBarFlag";
 import { getInPostSearchBarFmpEnabled } from "../../../lib/getInPostSearchBarFmpFlag";
@@ -415,7 +416,11 @@ async function BlogPostBody({ slug }: { slug: string }) {
       </div>
 
       {slug === FMP_SLUG ? (
-        <FmpSectionButtons content={content.content?.rendered || ''} slug={slug} />
+        <FmpViewWrapper
+          rawContent={content.content?.rendered || ''}
+          processedContent={processContentWithEmbeds(content.content?.rendered || '')}
+          slug={slug}
+        />
       ) : (
         <div className="container settings" style={{ padding: '0', marginBottom: '0', maxWidth: '100%' }}>
           <BlogContent content={processContentWithEmbeds(content.content?.rendered || '')} />
@@ -428,67 +433,3 @@ async function BlogPostBody({ slug }: { slug: string }) {
   );
 }
 
-function FmpSectionButtons({ content, slug }: { content: string; slug: string }) {
-  const sections = extractH1Sections(content);
-
-  if (sections.length === 0) {
-    return (
-      <div className="container settings" style={{ padding: '0', marginBottom: '0', maxWidth: '100%' }}>
-        <BlogContent content={processContentWithEmbeds(content)} />
-      </div>
-    );
-  }
-
-  return (
-    <div style={{ display: 'flex', flexDirection: 'column', width: '100%', maxWidth: '100%', boxSizing: 'border-box' }}>
-      <div className="list-group">
-        {sections.map((section) => (
-          <Link
-            key={section.slug}
-            href={`/blog/${slug}/${section.slug}`}
-            className="list3"
-            style={{
-              justifyContent: 'space-between',
-              textDecoration: 'none',
-              fontWeight: 600,
-              fontFamily: "'One UI Sans', sans-serif",
-              width: '100%',
-              maxWidth: '100%',
-              boxSizing: 'border-box',
-            }}
-          >
-            <span style={{ fontFamily: "'One UI Sans', sans-serif" }}>{section.title}</span>
-            <svg width="10" height="18" viewBox="0 0 10 18" fill="none" xmlns="http://www.w3.org/2000/svg" style={{ flexShrink: 0, opacity: 0.45 }}>
-              <path fillRule="evenodd" clipRule="evenodd" d="M0.43584 1.15216C0.14084 0.861162 0.13684 0.386162 0.42784 0.091162C0.71884 -0.202838 1.19384 -0.205838 1.48884 0.085162L9.26684 7.75516C9.60284 8.08616 9.78784 8.52916 9.78784 9.00116C9.78784 9.47216 9.60284 9.91616 9.26684 10.2472L1.48884 17.9162C1.34284 18.0592 1.15284 18.1312 0.96184 18.1312C0.76884 18.1312 0.57484 18.0562 0.42784 17.9082C0.13684 17.6132 0.14084 17.1382 0.43584 16.8472L8.21284 9.17816C8.27884 9.11516 8.28784 9.04016 8.28784 9.00116C8.28784 8.96216 8.27884 8.88616 8.21284 8.82316L0.43584 1.15216Z" fill="currentColor"/>
-            </svg>
-          </Link>
-        ))}
-      </div>
-
-      {/* Disclaimer — update name and email below */}
-      <div style={{
-        marginTop: 24,
-        padding: '20px 20px',
-        borderRadius: 'var(--br-9xl)',
-        background: 'var(--container-background)',
-        fontFamily: "'One UI Sans', sans-serif",
-        fontSize: '0.875rem',
-        lineHeight: 1.6,
-        color: 'var(--secondary)',
-        width: '100%',
-        maxWidth: '100%',
-        boxSizing: 'border-box',
-      }}>
-        <p style={{ margin: '0 0 8px 0' }}>
-          I confirm that the following website and associated work within is all my own work and does not include any work completed by anyone else other than myself.
-        </p>
-        <p style={{ margin: 0, fontWeight: 600, color: 'var(--primary)' }}>
-          Josh Skinner<br />
-          <a href="mailto:10694305@student.bpc.ac.uk" style={{ color: 'var(--accent)', textDecoration: 'none' }}>
-            10694305@student.bpc.ac.uk
-          </a>
-        </p>
-      </div>
-    </div>
-  );
-}

--- a/app/components/ThemeProvider.tsx
+++ b/app/components/ThemeProvider.tsx
@@ -63,6 +63,7 @@ interface ThemeContextType {
   liquidGlass: boolean;
   setLiquidGlass: (enabled: boolean) => void;
   liquidGlassAvailable: boolean;
+  fmpSeparatedViewAvailable: boolean;
   hydrated: boolean;
 }
 
@@ -80,6 +81,7 @@ const ThemeContext = createContext<ThemeContextType>({
   liquidGlass: false,
   setLiquidGlass: () => {},
   liquidGlassAvailable: false,
+  fmpSeparatedViewAvailable: false,
   hydrated: false,
 });
 
@@ -158,9 +160,10 @@ interface ThemeProviderProps {
   children: React.ReactNode;
   cornerSmoothingAvailable?: boolean;
   liquidGlassAvailable?: boolean;
+  fmpSeparatedViewAvailable?: boolean;
 }
 
-export function ThemeProvider({ children, cornerSmoothingAvailable = false, liquidGlassAvailable = false }: ThemeProviderProps) {
+export function ThemeProvider({ children, cornerSmoothingAvailable = false, liquidGlassAvailable = false, fmpSeparatedViewAvailable = false }: ThemeProviderProps) {
   const [theme, setTheme] = useState<Theme>(getInitialTheme);
   const [accentColor, setAccentColorState] = useState<AccentColor>(getInitialAccentColor);
   const [blurEnabled, setBlurEnabledState] = useState<boolean>(getInitialBlurEnabled);
@@ -304,7 +307,7 @@ export function ThemeProvider({ children, cornerSmoothingAvailable = false, liqu
   };
 
   return (
-    <ThemeContext.Provider value={{ theme, setTheme, accentColor, setAccentColor, blurEnabled, setBlurEnabled, cornerSmoothing, setCornerSmoothing, cornerSmoothingSupported, cornerSmoothingAvailable, liquidGlass, setLiquidGlass, liquidGlassAvailable, hydrated }}>
+    <ThemeContext.Provider value={{ theme, setTheme, accentColor, setAccentColor, blurEnabled, setBlurEnabled, cornerSmoothing, setCornerSmoothing, cornerSmoothingSupported, cornerSmoothingAvailable, liquidGlass, setLiquidGlass, liquidGlassAvailable, fmpSeparatedViewAvailable, hydrated }}>
       {children}
     </ThemeContext.Provider>
   );

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -3,6 +3,7 @@ import { BlogFlagProvider } from './components/BlogFlagProvider';
 import { getBlogEnabled } from '../lib/getBlogFlag';
 import { getCornerSmoothingEnabled } from '../lib/getCornerSmoothingFlag';
 import { getLiquidGlassEnabled } from '../lib/getLiquidGlassFlag';
+import { getFmpSeparatedViewEnabled } from '../lib/getFmpSeparatedViewFlag';
 import './globals.css';
 import { Analytics } from "@vercel/analytics/next"
 import { SpeedInsights } from "@vercel/speed-insights/next"
@@ -49,6 +50,7 @@ export default async function RootLayout({
   const blogEnabledValue = await getBlogEnabled();
   const cornerSmoothingEnabledValue = await getCornerSmoothingEnabled();
   const liquidGlassEnabledValue = await getLiquidGlassEnabled();
+  const fmpSeparatedViewEnabledValue = await getFmpSeparatedViewEnabled();
   
   return (
     <html suppressHydrationWarning>
@@ -103,7 +105,7 @@ export default async function RootLayout({
         />
       </head>
       <body>
-        <ThemeProvider cornerSmoothingAvailable={cornerSmoothingEnabledValue} liquidGlassAvailable={liquidGlassEnabledValue}>
+        <ThemeProvider cornerSmoothingAvailable={cornerSmoothingEnabledValue} liquidGlassAvailable={liquidGlassEnabledValue} fmpSeparatedViewAvailable={fmpSeparatedViewEnabledValue}>
           <BlogFlagProvider blogEnabled={blogEnabledValue}>
             <ProgressiveBlur />
             <ProgressiveBlur position="bottom" />

--- a/app/settings/feature-flags/page.tsx
+++ b/app/settings/feature-flags/page.tsx
@@ -69,6 +69,11 @@ const FLAGS: FlagDef[] = [
     description: 'Show the Liquid Glass toggle in Settings',
   },
   {
+    key: 'fmp-separated-view-enabled',
+    name: 'FMP view toggle',
+    description: 'Show the FMP separated/combined view toggle in Settings',
+  },
+  {
     key: 'wordpress-source-url',
     name: 'WordPress source URL',
     description: 'The WordPress site URL used as the blog data source',
@@ -223,7 +228,7 @@ function StringOverrideControl({
   };
 
   return (
-    <div style={{ display: 'flex', alignItems: 'center', gap: '10px', flexShrink: 0, minWidth: 0, flex: 1, justifyContent: 'flex-end' }}>
+    <div style={{ display: 'flex', alignItems: 'center', gap: '10px', minWidth: 0, width: '100%' }}>
       <button
         onClick={(e) => {
           e.stopPropagation();
@@ -281,7 +286,6 @@ function StringOverrideControl({
           outline: 'none',
           transition: 'opacity 0.15s ease-out, border-color 0.15s ease-out',
           width: '100%',
-          maxWidth: '260px',
           minWidth: 0,
         }}
         onFocus={(e) => {
@@ -386,8 +390,8 @@ function FeatureFlagsContent() {
             if (flag.type === 'string') {
               const value = mounted ? (stringOverrides[flag.key] ?? null) : null;
               return (
-                <div key={flag.key} className="list3" style={{ cursor: 'default', gap: '12px' }}>
-                  <div className="test-toggle-group" style={{ flex: '0 1 auto', minWidth: 0 }}>
+                <div key={flag.key} className="list3" style={{ cursor: 'default', flexDirection: 'column', alignItems: 'stretch', gap: '10px' }}>
+                  <div className="test-toggle-group">
                     <div className="body-text">{flag.name}</div>
                     <div className="information-wrapper">
                       <div className="information">{flag.description}</div>

--- a/app/settings/page.tsx
+++ b/app/settings/page.tsx
@@ -365,7 +365,7 @@ function SettingsContent() {
                 <div className="test-toggle-group">
                   <div className="body-text">Feature Flags</div>
                   <div className="information-wrapper">
-                    <div className="information">Locally override Vercel feature flags</div>
+                    <div className="information">Override server side feature flags</div>
                   </div>
                 </div>
                 <div className="list-item-separator" />

--- a/app/settings/page.tsx
+++ b/app/settings/page.tsx
@@ -80,6 +80,7 @@ function SettingsContent() {
   const { theme, setTheme, accentColor, setAccentColor, blurEnabled, setBlurEnabled, cornerSmoothing, setCornerSmoothing, cornerSmoothingSupported, cornerSmoothingAvailable, liquidGlass, setLiquidGlass, liquidGlassAvailable } = useTheme();
   const [mounted, setMounted] = useState(false);
   const [devOptionsEnabled, setDevOptionsEnabled] = useState(false);
+  const [fmpCombinedView, setFmpCombinedView] = useState(false);
   const searchParams = useSearchParams();
   const router = useRouter();
   const from = searchParams.get('from') || '/';
@@ -95,6 +96,7 @@ function SettingsContent() {
       setDevOptionsEnabled(localStorage.getItem('developer-options-enabled') === 'true');
     };
     checkDevOptions();
+    setFmpCombinedView(localStorage.getItem('fmpCombinedView') === 'true');
     window.addEventListener('developer-options-changed', checkDevOptions);
     return () => window.removeEventListener('developer-options-changed', checkDevOptions);
   }, []);
@@ -328,6 +330,24 @@ function SettingsContent() {
               <Switch id="liquid-glass-toggle" checked={liquidGlass} onChange={setLiquidGlass} />
             </label>
           )}
+        </div>
+
+        <div className="container1">
+          <div className="title">Blog</div>
+        </div>
+        <div className="list-group">
+          <label htmlFor="fmp-combined-view-toggle" className="list3" style={{ cursor: 'pointer' }}>
+            <div className="test-toggle-group">
+              <div className="body-text">FMP combined view</div>
+              <div className="information-wrapper">
+                <div className="information">Show all FMP sections on one page instead of separate pages</div>
+              </div>
+            </div>
+            <Switch id="fmp-combined-view-toggle" checked={fmpCombinedView} onChange={(val) => {
+              setFmpCombinedView(val);
+              localStorage.setItem('fmpCombinedView', val.toString());
+            }} />
+          </label>
         </div>
 
         {devOptionsEnabled && (

--- a/app/settings/page.tsx
+++ b/app/settings/page.tsx
@@ -77,11 +77,10 @@ function ThemePreviewAuto({ accent }: { accent: AccentColor }) {
 }
 
 function SettingsContent() {
-  const { theme, setTheme, accentColor, setAccentColor, blurEnabled, setBlurEnabled, cornerSmoothing, setCornerSmoothing, cornerSmoothingSupported, cornerSmoothingAvailable, liquidGlass, setLiquidGlass, liquidGlassAvailable } = useTheme();
+  const { theme, setTheme, accentColor, setAccentColor, blurEnabled, setBlurEnabled, cornerSmoothing, setCornerSmoothing, cornerSmoothingSupported, cornerSmoothingAvailable, liquidGlass, setLiquidGlass, liquidGlassAvailable, fmpSeparatedViewAvailable } = useTheme();
   const [mounted, setMounted] = useState(false);
   const [devOptionsEnabled, setDevOptionsEnabled] = useState(false);
   const [fmpSeparatedView, setFmpSeparatedView] = useState(true);
-  const [showFmpToggle, setShowFmpToggle] = useState(false);
   const searchParams = useSearchParams();
   const router = useRouter();
   const from = searchParams.get('from') || '/';
@@ -99,9 +98,6 @@ function SettingsContent() {
     checkDevOptions();
     const saved = localStorage.getItem('fmpCombinedView');
     setFmpSeparatedView(saved === null ? true : saved !== 'true');
-    const wpCookie = document.cookie.split('; ').find(c => c.startsWith('ff-wordpress-source-url='));
-    const wpUrl = wpCookie ? decodeURIComponent(wpCookie.split('=')[1]) : '';
-    setShowFmpToggle(wpUrl.includes('joshskinnertjg.wordpress.com'));
     window.addEventListener('developer-options-changed', checkDevOptions);
     return () => window.removeEventListener('developer-options-changed', checkDevOptions);
   }, []);
@@ -337,7 +333,7 @@ function SettingsContent() {
           )}
         </div>
 
-        {showFmpToggle && (
+        {fmpSeparatedViewAvailable && (
           <>
             <div className="container1">
               <div className="title">Blog</div>

--- a/app/settings/page.tsx
+++ b/app/settings/page.tsx
@@ -81,6 +81,7 @@ function SettingsContent() {
   const [mounted, setMounted] = useState(false);
   const [devOptionsEnabled, setDevOptionsEnabled] = useState(false);
   const [fmpSeparatedView, setFmpSeparatedView] = useState(true);
+  const [showFmpToggle, setShowFmpToggle] = useState(false);
   const searchParams = useSearchParams();
   const router = useRouter();
   const from = searchParams.get('from') || '/';
@@ -98,6 +99,9 @@ function SettingsContent() {
     checkDevOptions();
     const saved = localStorage.getItem('fmpCombinedView');
     setFmpSeparatedView(saved === null ? true : saved !== 'true');
+    const wpCookie = document.cookie.split('; ').find(c => c.startsWith('ff-wordpress-source-url='));
+    const wpUrl = wpCookie ? decodeURIComponent(wpCookie.split('=')[1]) : '';
+    setShowFmpToggle(wpUrl.includes('joshskinnertjg.wordpress.com'));
     window.addEventListener('developer-options-changed', checkDevOptions);
     return () => window.removeEventListener('developer-options-changed', checkDevOptions);
   }, []);
@@ -333,23 +337,27 @@ function SettingsContent() {
           )}
         </div>
 
-        <div className="container1">
-          <div className="title">Blog</div>
-        </div>
-        <div className="list-group">
-          <label htmlFor="fmp-combined-view-toggle" className="list3" style={{ cursor: 'pointer' }}>
-            <div className="test-toggle-group">
-              <div className="body-text">FMP separated view</div>
-              <div className="information-wrapper">
-                <div className="information">Show FMP sections on separate pages instead of one combined page</div>
-              </div>
+        {showFmpToggle && (
+          <>
+            <div className="container1">
+              <div className="title">Blog</div>
             </div>
-            <Switch id="fmp-combined-view-toggle" checked={fmpSeparatedView} onChange={(val) => {
-              setFmpSeparatedView(val);
-              localStorage.setItem('fmpCombinedView', (!val).toString());
-            }} />
-          </label>
-        </div>
+            <div className="list-group">
+              <label htmlFor="fmp-combined-view-toggle" className="list3" style={{ cursor: 'pointer' }}>
+                <div className="test-toggle-group">
+                  <div className="body-text">FMP separated view</div>
+                  <div className="information-wrapper">
+                    <div className="information">Show FMP sections on separate pages instead of one combined page</div>
+                  </div>
+                </div>
+                <Switch id="fmp-combined-view-toggle" checked={fmpSeparatedView} onChange={(val) => {
+                  setFmpSeparatedView(val);
+                  localStorage.setItem('fmpCombinedView', (!val).toString());
+                }} />
+              </label>
+            </div>
+          </>
+        )}
 
         {devOptionsEnabled && (
           <>

--- a/app/settings/page.tsx
+++ b/app/settings/page.tsx
@@ -80,7 +80,7 @@ function SettingsContent() {
   const { theme, setTheme, accentColor, setAccentColor, blurEnabled, setBlurEnabled, cornerSmoothing, setCornerSmoothing, cornerSmoothingSupported, cornerSmoothingAvailable, liquidGlass, setLiquidGlass, liquidGlassAvailable } = useTheme();
   const [mounted, setMounted] = useState(false);
   const [devOptionsEnabled, setDevOptionsEnabled] = useState(false);
-  const [fmpCombinedView, setFmpCombinedView] = useState(false);
+  const [fmpSeparatedView, setFmpSeparatedView] = useState(true);
   const searchParams = useSearchParams();
   const router = useRouter();
   const from = searchParams.get('from') || '/';
@@ -96,7 +96,8 @@ function SettingsContent() {
       setDevOptionsEnabled(localStorage.getItem('developer-options-enabled') === 'true');
     };
     checkDevOptions();
-    setFmpCombinedView(localStorage.getItem('fmpCombinedView') === 'true');
+    const saved = localStorage.getItem('fmpCombinedView');
+    setFmpSeparatedView(saved === null ? true : saved !== 'true');
     window.addEventListener('developer-options-changed', checkDevOptions);
     return () => window.removeEventListener('developer-options-changed', checkDevOptions);
   }, []);
@@ -338,14 +339,14 @@ function SettingsContent() {
         <div className="list-group">
           <label htmlFor="fmp-combined-view-toggle" className="list3" style={{ cursor: 'pointer' }}>
             <div className="test-toggle-group">
-              <div className="body-text">FMP combined view</div>
+              <div className="body-text">FMP separated view</div>
               <div className="information-wrapper">
-                <div className="information">Show all FMP sections on one page instead of separate pages</div>
+                <div className="information">Show FMP sections on separate pages instead of one combined page</div>
               </div>
             </div>
-            <Switch id="fmp-combined-view-toggle" checked={fmpCombinedView} onChange={(val) => {
-              setFmpCombinedView(val);
-              localStorage.setItem('fmpCombinedView', val.toString());
+            <Switch id="fmp-combined-view-toggle" checked={fmpSeparatedView} onChange={(val) => {
+              setFmpSeparatedView(val);
+              localStorage.setItem('fmpCombinedView', (!val).toString());
             }} />
           </label>
         </div>

--- a/flags.ts
+++ b/flags.ts
@@ -138,6 +138,21 @@ export const liquidGlassEnabled = flag({
 });
 
 /**
+ * FMP Separated View feature flag - controls visibility of the FMP view toggle in Settings.
+ * When enabled, the toggle appears allowing users to switch between separated and combined views.
+ */
+export const fmpSeparatedViewEnabled = flag({
+  key: 'fmp-separated-view-enabled',
+  adapter: vercelAdapter(),
+  defaultValue: false,
+  description: 'Show the FMP separated/combined view toggle in Settings',
+  options: [
+    { value: true, label: 'Enabled' },
+    { value: false, label: 'Disabled' },
+  ],
+});
+
+/**
  * WordPress source URL flag - controls which WordPress site the blog loads from.
  * Configure per-environment in the Vercel Dashboard (e.g. college vs main site).
  */

--- a/lib/getFmpSeparatedViewFlag.ts
+++ b/lib/getFmpSeparatedViewFlag.ts
@@ -1,0 +1,24 @@
+/**
+ * Gets the fmp-separated-view-enabled flag value.
+ * Checks for a local developer override cookie (ff-fmp-separated-view-enabled) first.
+ * Uses Vercel Flags when FLAGS env var is set, otherwise falls back to false.
+ */
+export async function getFmpSeparatedViewEnabled(): Promise<boolean> {
+  try {
+    const { cookies } = await import('next/headers');
+    const cookieStore = await cookies();
+    const override = cookieStore.get('ff-fmp-separated-view-enabled');
+    if (override) return override.value === 'true';
+  } catch {
+    // cookies() not available during static generation
+  }
+  if (!process.env.FLAGS) {
+    return false;
+  }
+  try {
+    const { fmpSeparatedViewEnabled } = await import('../flags');
+    return Boolean(await fmpSeparatedViewEnabled());
+  } catch {
+    return false;
+  }
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a toggle in Settings to switch the FMP blog post between **separated view** (section link list -- the current/default behavior) and **combined view** (all content rendered inline on one page). The toggle is gated behind a feature flag (`fmp-separated-view-enabled`).

## Changes

### New file: `app/blog/[slug]/FmpViewWrapper.tsx`
Client component that reads `localStorage('fmpCombinedView')` and conditionally renders:
- **Separated view** (default): section link list with chevrons, matching the existing behavior
- **Combined view**: full post content rendered inline via `BlogContent`

Both views include the academic disclaimer block at the bottom.

### New file: `lib/getFmpSeparatedViewFlag.ts`
Server-side getter for the `fmp-separated-view-enabled` flag, following the same cookie-override-then-Vercel-Flags pattern as other flag getters.

### Modified: `flags.ts`
Added `fmpSeparatedViewEnabled` flag definition (default: `false`).

### Modified: `app/components/ThemeProvider.tsx`
Added `fmpSeparatedViewAvailable` to the theme context interface, props, and provider value -- matching the existing pattern for `cornerSmoothingAvailable` and `liquidGlassAvailable`.

### Modified: `app/layout.tsx`
Resolves the new flag server-side and passes it to `ThemeProvider`.

### Modified: `app/blog/[slug]/page.tsx`
- Replaced the inline `FmpSectionButtons` component with `FmpViewWrapper`
- Server component passes both `rawContent` and `processedContent`

### Modified: `app/settings/page.tsx`
- Added "Blog" section with "FMP separated view" toggle, gated by `fmpSeparatedViewAvailable` from the theme context
- Toggle state backed by `localStorage` key `fmpCombinedView`

### Modified: `app/settings/feature-flags/page.tsx`
- Added `fmp-separated-view-enabled` to the feature flag override list
- Changed WordPress Source URL text input layout: label and description are now above the input field (vertical stack) instead of side-by-side, with full-width input
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-de1e30e9-37a5-4671-bf26-5fb7d4740ffe"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-de1e30e9-37a5-4671-bf26-5fb7d4740ffe"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

