### PR TITLE
Add automated Notion wiki sync workflows and documentation

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -9,9 +9,9 @@ name: Claude
 #
 # Requires repository secrets: CLAUDE_CODE_OAUTH_TOKEN (from
 # `claude setup-token`, billed to your Claude subscription), NOTION_TOKEN.
-# Comments are posted as github-actions[bot]. If you install the Claude
-# GitHub App (https://github.com/apps/claude), remove the github_token input
-# below to get a proper Claude identity via the OIDC exchange instead.
+# Auth uses the Claude GitHub App (https://github.com/apps/claude) via OIDC,
+# so replies are posted under the Claude bot identity. If you ever uninstall
+# the app, add `github_token: secrets.GITHUB_TOKEN` back to the action inputs.
 
 on:
   issue_comment:
@@ -46,7 +46,6 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          github_token: ${{ secrets.GITHUB_TOKEN }}
           claude_args: |
             --mcp-config '{"mcpServers":{"notion":{"command":"npx","args":["-y","@notionhq/notion-mcp-server"],"env":{"NOTION_TOKEN":"${{ secrets.NOTION_TOKEN }}"}}}}'
             --allowedTools "Bash(git:*),Bash(gh:*),Bash(npm run lint),Bash(npm test:*),Read,Grep,Glob,Edit,Write,mcp__notion__*"

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -1,0 +1,49 @@
+name: Claude
+
+# Interactive @claude bot: mention @claude in any PR/issue comment or review
+# to get an agent with full repo context. Because the Notion MCP server is
+# configured here, you can also say things like
+#   "@claude update the Notion docs for this PR now"
+# and it will edit the TJG Site Docs wiki directly (page map lives in
+# docs/NOTION_DOCS.md).
+#
+# Requires repository secrets: ANTHROPIC_API_KEY, NOTION_TOKEN.
+# Installing the Claude GitHub App (https://github.com/apps/claude) gives the
+# bot a nicer identity, but the default GITHUB_TOKEN works.
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+  pull_request_review:
+    types: [submitted]
+  issues:
+    types: [opened, assigned]
+
+jobs:
+  claude:
+    if: |
+      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
+      (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
+      id-token: write
+      actions: read
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Run Claude
+        uses: anthropics/claude-code-action@v1
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          claude_args: |
+            --mcp-config '{"mcpServers":{"notion":{"command":"npx","args":["-y","@notionhq/notion-mcp-server"],"env":{"NOTION_TOKEN":"${{ secrets.NOTION_TOKEN }}"}}}}'
+            --allowedTools "Bash(git:*),Bash(gh:*),Bash(npm run lint),Bash(npm test:*),Read,Grep,Glob,Edit,Write,mcp__notion__*"

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -7,7 +7,8 @@ name: Claude
 # and it will edit the TJG Site Docs wiki directly (page map lives in
 # docs/NOTION_DOCS.md).
 #
-# Requires repository secrets: ANTHROPIC_API_KEY, NOTION_TOKEN.
+# Requires repository secrets: CLAUDE_CODE_OAUTH_TOKEN (from
+# `claude setup-token`, billed to your Claude subscription), NOTION_TOKEN.
 # Installing the Claude GitHub App (https://github.com/apps/claude) gives the
 # bot a nicer identity, but the default GITHUB_TOKEN works.
 
@@ -43,7 +44,7 @@ jobs:
       - name: Run Claude
         uses: anthropics/claude-code-action@v1
         with:
-          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           claude_args: |
             --mcp-config '{"mcpServers":{"notion":{"command":"npx","args":["-y","@notionhq/notion-mcp-server"],"env":{"NOTION_TOKEN":"${{ secrets.NOTION_TOKEN }}"}}}}'
             --allowedTools "Bash(git:*),Bash(gh:*),Bash(npm run lint),Bash(npm test:*),Read,Grep,Glob,Edit,Write,mcp__notion__*"

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -9,8 +9,9 @@ name: Claude
 #
 # Requires repository secrets: CLAUDE_CODE_OAUTH_TOKEN (from
 # `claude setup-token`, billed to your Claude subscription), NOTION_TOKEN.
-# Installing the Claude GitHub App (https://github.com/apps/claude) gives the
-# bot a nicer identity, but the default GITHUB_TOKEN works.
+# Comments are posted as github-actions[bot]. If you install the Claude
+# GitHub App (https://github.com/apps/claude), remove the github_token input
+# below to get a proper Claude identity via the OIDC exchange instead.
 
 on:
   issue_comment:
@@ -45,6 +46,7 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
           claude_args: |
             --mcp-config '{"mcpServers":{"notion":{"command":"npx","args":["-y","@notionhq/notion-mcp-server"],"env":{"NOTION_TOKEN":"${{ secrets.NOTION_TOKEN }}"}}}}'
             --allowedTools "Bash(git:*),Bash(gh:*),Bash(npm run lint),Bash(npm test:*),Read,Grep,Glob,Edit,Write,mcp__notion__*"

--- a/.github/workflows/docs-impact-review.yml
+++ b/.github/workflows/docs-impact-review.yml
@@ -1,0 +1,65 @@
+name: Docs impact review
+
+# Inline PR bot: when a PR is opened or updated against main or beta, Claude
+# reviews the diff and posts a single "Docs impact" comment on the PR listing
+# which Notion wiki pages will need updating once the PR merges (or saying
+# there's no docs impact). The actual wiki edit happens after merge via
+# update-docs.yml; this is the early-warning half of the system.
+#
+# Requires the ANTHROPIC_API_KEY repository secret (no Notion access needed —
+# this workflow only reads the repo and comments on the PR).
+
+on:
+  pull_request:
+    types: [opened, synchronize, ready_for_review]
+    branches: [main, beta]
+
+concurrency:
+  group: docs-impact-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  docs-impact:
+    if: github.event.pull_request.draft == false
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Review docs impact
+        uses: anthropics/claude-code-action@v1
+        env:
+          GH_TOKEN: ${{ github.token }}
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          claude_args: |
+            --allowedTools "Bash(git log:*),Bash(git diff:*),Bash(git show:*),Bash(gh pr comment:*),Read,Grep,Glob"
+          prompt: |
+            You are the documentation-impact reviewer for this repository. The
+            developer docs live in a Notion wiki; the list of wiki pages and what
+            each covers is in docs/NOTION_DOCS.md — read it first.
+
+            This is PR #${{ github.event.pull_request.number }} targeting
+            ${{ github.base_ref }}. Review the PR diff:
+              git diff origin/${{ github.base_ref }}...HEAD
+
+            Decide which wiki pages (if any) the change makes stale. Things that
+            almost always have docs impact: feature flags, env vars, routes,
+            dependencies, localStorage/cookie keys, CMS/data-source changes,
+            removed features, CSS class renames, third-party service setup.
+            Pure refactors, lockfile churn, and content tweaks usually have none.
+
+            Then post exactly one comment on the PR using:
+              gh pr comment ${{ github.event.pull_request.number }} --edit-last --create-if-none --body "..."
+
+            Comment format:
+            - Title line: "📚 **Docs impact**"
+            - If impact: a short bullet list — affected wiki page name → one line
+              on what needs updating there. End with: "These will be applied to
+              the Notion wiki automatically after merge."
+            - If none: a single line saying no documentation impact.
+            Keep it tight; this is a heads-up, not a review.

--- a/.github/workflows/docs-impact-review.yml
+++ b/.github/workflows/docs-impact-review.yml
@@ -37,6 +37,9 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          # Use the workflow's own token instead of the OIDC exchange, which
+          # requires the Claude GitHub App to be installed.
+          github_token: ${{ secrets.GITHUB_TOKEN }}
           claude_args: |
             --allowedTools "Bash(git log:*),Bash(git diff:*),Bash(git show:*),Bash(gh pr comment:*),Read,Grep,Glob"
           prompt: |

--- a/.github/workflows/docs-impact-review.yml
+++ b/.github/workflows/docs-impact-review.yml
@@ -6,8 +6,9 @@ name: Docs impact review
 # there's no docs impact). The actual wiki edit happens after merge via
 # update-docs.yml; this is the early-warning half of the system.
 #
-# Requires the ANTHROPIC_API_KEY repository secret (no Notion access needed —
-# this workflow only reads the repo and comments on the PR).
+# Requires the CLAUDE_CODE_OAUTH_TOKEN repository secret (from
+# `claude setup-token`, billed to your Claude subscription). No Notion access
+# needed — this workflow only reads the repo and comments on the PR.
 
 on:
   pull_request:
@@ -35,7 +36,7 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         with:
-          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           claude_args: |
             --allowedTools "Bash(git log:*),Bash(git diff:*),Bash(git show:*),Bash(gh pr comment:*),Read,Grep,Glob"
           prompt: |

--- a/.github/workflows/update-docs.yml
+++ b/.github/workflows/update-docs.yml
@@ -37,6 +37,9 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          # Use the workflow's own token instead of the OIDC exchange, which
+          # requires the Claude GitHub App to be installed.
+          github_token: ${{ secrets.GITHUB_TOKEN }}
           claude_args: |
             --allowedTools "Bash(git log:*),Bash(git diff:*),Bash(git show:*),Read,Grep,Glob,mcp__notion__*"
             --mcp-config '{"mcpServers":{"notion":{"command":"npx","args":["-y","@notionhq/notion-mcp-server"],"env":{"NOTION_TOKEN":"${{ secrets.NOTION_TOKEN }}"}}}}'

--- a/.github/workflows/update-docs.yml
+++ b/.github/workflows/update-docs.yml
@@ -3,9 +3,13 @@ name: Update Notion docs
 # Keeps the "TJG Site Docs" Notion wiki in sync with the codebase.
 # Runs after a PR merges into main or beta (or manually via workflow_dispatch).
 # Requires two repository secrets:
-#   ANTHROPIC_API_KEY - https://console.anthropic.com
-#   NOTION_TOKEN      - internal Notion integration token; the integration must
-#                       be given access to the "TJG Site Docs" wiki page.
+#   CLAUDE_CODE_OAUTH_TOKEN - run `claude setup-token` locally while logged in
+#                             with your Claude Pro/Max account and paste the
+#                             result (uses your subscription, not API billing).
+#                             To use API billing instead, swap the input below
+#                             for: anthropic_api_key: secrets.ANTHROPIC_API_KEY
+#   NOTION_TOKEN            - internal Notion integration token; the integration
+#                             must be given access to the "TJG Site Docs" wiki.
 # See docs/NOTION_DOCS.md for full setup instructions and the wiki page map.
 
 on:
@@ -32,7 +36,7 @@ jobs:
       - name: Update wiki from merged changes
         uses: anthropics/claude-code-action@v1
         with:
-          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           claude_args: |
             --allowedTools "Bash(git log:*),Bash(git diff:*),Bash(git show:*),Read,Grep,Glob,mcp__notion__*"
             --mcp-config '{"mcpServers":{"notion":{"command":"npx","args":["-y","@notionhq/notion-mcp-server"],"env":{"NOTION_TOKEN":"${{ secrets.NOTION_TOKEN }}"}}}}'

--- a/.github/workflows/update-docs.yml
+++ b/.github/workflows/update-docs.yml
@@ -1,0 +1,65 @@
+name: Update Notion docs
+
+# Keeps the "TJG Site Docs" Notion wiki in sync with the codebase.
+# Runs after a PR merges into main or beta (or manually via workflow_dispatch).
+# Requires two repository secrets:
+#   ANTHROPIC_API_KEY - https://console.anthropic.com
+#   NOTION_TOKEN      - internal Notion integration token; the integration must
+#                       be given access to the "TJG Site Docs" wiki page.
+# See docs/NOTION_DOCS.md for full setup instructions and the wiki page map.
+
+on:
+  pull_request:
+    types: [closed]
+    branches: [main, beta]
+  workflow_dispatch:
+
+concurrency:
+  group: update-notion-docs
+  cancel-in-progress: false
+
+jobs:
+  update-docs:
+    if: github.event_name == 'workflow_dispatch' || github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Update wiki from merged changes
+        uses: anthropics/claude-code-action@v1
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          claude_args: |
+            --allowedTools "Bash(git log:*),Bash(git diff:*),Bash(git show:*),Read,Grep,Glob,mcp__notion__*"
+            --mcp-config '{"mcpServers":{"notion":{"command":"npx","args":["-y","@notionhq/notion-mcp-server"],"env":{"NOTION_TOKEN":"${{ secrets.NOTION_TOKEN }}"}}}}'
+          prompt: |
+            You are the documentation maintainer for this repository. The developer
+            docs live in the Notion wiki "TJG Site Docs". The wiki home page and the
+            ID of every documentation page are listed in docs/NOTION_DOCS.md — read
+            that file first.
+
+            Current branch: ${{ github.base_ref || github.ref_name }}
+
+            1. Fetch the wiki home page. The blockquote near the top records the
+               last documented commit for each branch (e.g. "main @ <sha>").
+            2. Run `git log <last-documented-sha>..HEAD --oneline` and
+               `git diff <last-documented-sha>..HEAD --stat` to see what changed.
+               If the recorded sha is unknown to git, fall back to documenting the
+               merged PR's diff only.
+            3. Read the changed source files as needed to understand the changes.
+            4. Update ONLY the Notion wiki pages whose content is now stale:
+               edit the affected sections in place (notion-update-page with
+               update_content); do not rewrite whole pages, do not create new pages
+               unless a genuinely new subsystem was added, and never delete pages.
+               Pay special attention to: feature flags added/removed, env vars,
+               routes, dependencies, localStorage/cookie keys, and anything listed
+               on the "Quirks, Easter Eggs & Gotchas" page.
+            5. Finally, update the home page blockquote so this branch's entry
+               reads the new HEAD sha (short form) and today's date.
+
+            If nothing user-facing or developer-facing changed (e.g. only lockfile
+            or build-info churn), update only the home page blockquote and stop.

--- a/docs/NOTION_DOCS.md
+++ b/docs/NOTION_DOCS.md
@@ -37,8 +37,13 @@ Three workflows keep the wiki in sync:
 
 ### One-time setup
 
-1. **Anthropic API key**: create one at https://console.anthropic.com and add it
-   as the `ANTHROPIC_API_KEY` repository secret.
+1. **Claude auth**: run `claude setup-token` locally while logged in to Claude
+   Code with your Claude Pro/Max account, and add the resulting token as the
+   `CLAUDE_CODE_OAUTH_TOKEN` repository secret. CI runs are then covered by the
+   subscription (they share its rate limits). Alternative: use API billing by
+   adding an `ANTHROPIC_API_KEY` secret and switching the
+   `claude_code_oauth_token` input back to `anthropic_api_key` in the three
+   workflow files.
 2. **Notion integration**: at https://www.notion.so/profile/integrations create an
    internal integration with read + update + insert content capabilities, then in
    Notion open the TJG Site Docs wiki → ••• → Connections → add the integration.

--- a/docs/NOTION_DOCS.md
+++ b/docs/NOTION_DOCS.md
@@ -1,0 +1,45 @@
+# Notion documentation wiki
+
+Developer documentation for this site lives in the **TJG Site Docs** Notion wiki:
+https://www.notion.so/37d59b88f2b18072b5fcc8f29814afff
+
+The wiki home page is the central hub: it has a reading guide, quick facts, and a
+callout recording the last commit each branch was documented at.
+
+## Page map
+
+| Page | Notion page ID |
+| --- | --- |
+| Wiki home (hub / index) | `37d59b88f2b18072b5fcc8f29814afff` |
+| Site Overview & Architecture | `37d59b88f2b1813d8ea6d382c6082153` |
+| Design System & Theming | `37d59b88f2b181ecb942de065ba3b77e` |
+| Navigation & Core Components | `37d59b88f2b181478070f0b0fc4fd668` |
+| Blog System (WordPress) | `37d59b88f2b181cc9484c331a16e5df2` |
+| Feature Flags | `37d59b88f2b1810b841ec4c5770a4550` |
+| Pages Reference | `37d59b88f2b181e4a729d26c2244d867` |
+| Integrations, APIs & Environment Variables | `37d59b88f2b18174baa6c78fdd6b219a` |
+| Quirks, Easter Eggs & Gotchas | `37d59b88f2b18108a3f6ff5ed6ca8ffe` |
+| Beta Branch — Sanity Migration | `37d59b88f2b181658361ff7eb1891950` |
+
+## Automated updates
+
+`.github/workflows/update-docs.yml` runs Claude Code after every PR merged into
+`main` or `beta` (and on manual dispatch). It diffs the repo against the last
+documented commit recorded on the wiki home page, updates the stale wiki
+sections via the Notion MCP server, then bumps the recorded commit.
+
+### One-time setup
+
+1. **Anthropic API key**: create one at https://console.anthropic.com and add it
+   as the `ANTHROPIC_API_KEY` repository secret.
+2. **Notion integration**: at https://www.notion.so/profile/integrations create an
+   internal integration with read + update + insert content capabilities, then in
+   Notion open the TJG Site Docs wiki → ••• → Connections → add the integration.
+   Add its token as the `NOTION_TOKEN` repository secret.
+
+### Manual / agent updates
+
+Any agent (Claude Code session, etc.) making a significant change should also
+update the affected wiki pages and the home-page callout. The same page map
+above applies. Keep edits surgical: update stale sections in place rather than
+regenerating whole pages, so manual edits made by humans survive.

--- a/docs/NOTION_DOCS.md
+++ b/docs/NOTION_DOCS.md
@@ -23,10 +23,17 @@ callout recording the last commit each branch was documented at.
 
 ## Automated updates
 
-`.github/workflows/update-docs.yml` runs Claude Code after every PR merged into
-`main` or `beta` (and on manual dispatch). It diffs the repo against the last
-documented commit recorded on the wiki home page, updates the stale wiki
-sections via the Notion MCP server, then bumps the recorded commit.
+Three workflows keep the wiki in sync:
+
+- `.github/workflows/docs-impact-review.yml` — **inline PR bot**: posts a
+  "Docs impact" comment on every PR into `main`/`beta`, listing which wiki
+  pages the change will make stale (or confirming there's no impact).
+- `.github/workflows/update-docs.yml` — **after merge**: diffs the repo against
+  the last documented commit recorded on the wiki home page, updates the stale
+  wiki sections via the Notion MCP server, then bumps the recorded commit.
+- `.github/workflows/claude.yml` — **on demand**: mention `@claude` in any PR
+  or issue comment (e.g. "@claude update the Notion docs for this PR now");
+  the bot has Notion access and this page map.
 
 ### One-time setup
 


### PR DESCRIPTION
## Summary

This PR establishes an automated system to keep the "TJG Site Docs" Notion wiki in sync with the codebase. It introduces three GitHub Actions workflows powered by Claude Code and the Notion MCP server, along with setup documentation.

## Key Changes

- **`.github/workflows/docs-impact-review.yml`** — Inline PR bot that reviews each PR targeting `main` or `beta` and posts a "Docs impact" comment listing which wiki pages will need updating (or confirming no impact). Runs on PR open/update/ready-for-review.

- **`.github/workflows/update-docs.yml`** — Post-merge automation that diffs the repo against the last documented commit recorded on the wiki home page, updates stale wiki sections via the Notion MCP server, and bumps the recorded commit. Runs after PR merge or on manual trigger.

- **`.github/workflows/claude.yml`** — Interactive `@claude` bot for on-demand agent assistance. Responds to mentions in PR/issue comments and reviews with full repo context and Notion access, enabling manual wiki updates via natural language (e.g., "@claude update the Notion docs for this PR now").

- **`docs/NOTION_DOCS.md`** — Setup guide and reference documentation including:
  - Link to the TJG Site Docs wiki home page
  - Complete page map (wiki page names → Notion page IDs)
  - Overview of the three automated workflows
  - One-time setup instructions (Claude auth token, Notion integration)
  - Guidelines for manual/agent updates

## Notable Implementation Details

- All workflows use `anthropics/claude-code-action@v1` with Claude Code OAuth tokens (billed to Claude Pro/Max subscription) rather than API keys, reducing operational costs.
- The Notion MCP server is configured via `mcp-config` in workflows that need it (`update-docs.yml` and `claude.yml`).
- `docs-impact-review.yml` uses concurrency to cancel in-progress reviews when a PR is updated, keeping feedback current.
- `update-docs.yml` uses `cancel-in-progress: false` to ensure merge-triggered updates complete sequentially.
- Workflows include detailed prompts guiding Claude to read the page map, understand changes, update only stale sections (not regenerate whole pages), and preserve manual edits.
- Setup requires two repository secrets: `CLAUDE_CODE_OAUTH_TOKEN` and `NOTION_TOKEN`.

https://claude.ai/code/session_01CA3hgFxz643KyAodsfNVsu